### PR TITLE
fix for issue #5

### DIFF
--- a/picklayer.py
+++ b/picklayer.py
@@ -199,7 +199,7 @@ class pickLayer:
                     except:
                         customIcon = QtGui.QIcon(os.path.join(self.plugin_dir,"icons","customAction.png"))
                     newActionItem = contextMenu.addAction(customIcon,action.name())
-                    newActionItem.triggered.connect(partial(self.customAction,actionOrder))
+                    newActionItem.triggered.connect(partial(self.customAction,action.id()))
                     actionOrder += 1
         contextMenu.exec_(QtGui.QCursor.pos())
 


### PR DESCRIPTION
Fix for issue https://github.com/enricofer/pickLayer/issues/5

doActionFeature expects the actionid to be a QUuid, not an integer.

( 	QUuid  	actionId,
		const QgsFeature &  	feature,
		int  	defaultValueIndex = 0,
		const QgsExpressionContextScope &  	scope = QgsExpressionContextScope() 
	) 	

available in Python bindings as doActionFeature